### PR TITLE
Add sign text formatting utility and apply to sign placement

### DIFF
--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -5,7 +5,7 @@ use crate::element_processing::*;
 use crate::ground::Ground;
 use crate::osm_parser::ProcessedElement;
 use crate::progress::emit_gui_progress_update;
-use crate::world_editor::WorldEditor;
+use crate::world_editor::{format_sign_text, WorldEditor};
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
 
@@ -202,16 +202,8 @@ pub fn generate_world(
     }
 
     // Set sign for player orientation
-    /*editor.set_sign(
-        "↑".to_string(),
-        "Generated World".to_string(),
-        "This direction".to_string(),
-        "".to_string(),
-        9,
-        -61,
-        9,
-        6,
-    );*/
+    let (line1, line2, line3, line4) = format_sign_text("↑\nGenerated World\nThis direction\n");
+    editor.set_sign(line1, line2, line3, line4, 9, -61, 9, 6);
 
     ground_pb.inc(block_counter % batch_size);
     ground_pb.finish();

--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -14,6 +14,41 @@ use std::fs::File;
 use std::io::Write;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+/// Formats a single text string into four lines suitable for Minecraft signs.
+/// Each line is limited to 15 characters and double quotes are replaced with
+/// single quotes to keep the resulting NBT valid.
+pub fn format_sign_text(text: &str) -> (String, String, String, String) {
+    let sanitized = text.replace('"', "'");
+    let mut lines = vec![String::new()];
+
+    for ch in sanitized.chars() {
+        let current = lines.last_mut().expect("lines is never empty");
+
+        if ch == '\n' || current.chars().count() >= 15 {
+            if lines.len() == 4 {
+                break;
+            }
+            lines.push(String::new());
+            if ch == '\n' {
+                continue;
+            }
+        }
+
+        lines.last_mut().unwrap().push(ch);
+    }
+
+    while lines.len() < 4 {
+        lines.push(String::new());
+    }
+
+    (
+        lines[0].clone(),
+        lines[1].clone(),
+        lines[2].clone(),
+        lines[3].clone(),
+    )
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct Chunk {


### PR DESCRIPTION
## Summary
- Add `format_sign_text` helper to split text into sign lines and sanitize quotes
- Use the new formatter for player orientation sign

## Testing
- `cargo test --no-default-features` *(failed: error sending request for overpass API)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6f0d35d0832fb87eb9f77d6f74a9