### PR TITLE
Use fully qualified fs2 unlock

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -53,7 +53,7 @@ impl SessionLock {
 impl Drop for SessionLock {
     fn drop(&mut self) {
         // Release the lock and remove the session.lock file
-        let _ = self.file.unlock();
+        let _ = fs2::FileExt::unlock(&self.file);
         let _ = fs::remove_file(&self.path);
     }
 }


### PR DESCRIPTION
## Summary
- avoid future standard library name collision by using fully qualified unlock from fs2::FileExt

## Testing
- `cargo build --all-targets --all-features --release` *(fails: blocking waiting for file lock on build directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c49134f7dc832f92fc97db830d8c71