### PR TITLE
Ensure street-name signs override existing blocks

### DIFF
--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -482,7 +482,12 @@ impl<'a> WorldEditor<'a> {
         )]));
         let sign_block = BlockWithProperties::new(SIGN, Some(sign_properties));
 
-        self.set_block_with_properties(sign_block, x, y, z, None, None);
+        // Ensure that the sign is always placed even if another block
+        // already occupies the target position. An empty blacklist allows
+        // overriding any existing block, which is necessary because signs
+        // are typically placed next to roads where terrain or vegetation
+        // might have been generated earlier.
+        self.set_block_with_properties(sign_block, x, y, z, None, Some(&[]));
     }
 
     /// Sets a block of the specified type at the given coordinates.


### PR DESCRIPTION
## Summary
- Always place street-name signs by overriding any existing block

## Testing
- `cargo test` *(fails: test_translate_by_vector – Failed to fetch data: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68c49afcab0c832fb0505b72fe28cea6