### PR TITLE
Log sign height and ensure solid support for highway signs

### DIFF
--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -347,8 +347,9 @@ pub fn generate_highways(editor: &mut WorldEditor, element: &ProcessedElement, a
                                 let sign_z = z + side_dz * (block_range + 1);
                                 let (min_x, min_z) = editor.get_min_coords();
                                 let (max_x, max_z) = editor.get_max_coords();
+                                let sign_y = editor.get_absolute_y(sign_x, 1, sign_z);
                                 eprintln!(
-                                    "  Attempting sign for '{name}' at ({sign_x}, {sign_z}) with rotation {rotation}"
+                                    "  Attempting sign for '{name}' at ({sign_x}, {sign_y}, {sign_z}) with rotation {rotation}"
                                 );
                                 if sign_x >= min_x
                                     && sign_x <= max_x
@@ -356,14 +357,14 @@ pub fn generate_highways(editor: &mut WorldEditor, element: &ProcessedElement, a
                                     && sign_z <= max_z
                                 {
                                     eprintln!(
-                                        "  Placing sign for '{name}' at ({sign_x}, {sign_z})"
+                                        "  Placing sign for '{name}' at ({sign_x}, {sign_y}, {sign_z})"
                                     );
                                     let (l1, l2, l3, l4) = format_sign_text(name);
                                     editor.set_sign(l1, l2, l3, l4, sign_x, 1, sign_z, rotation);
                                     sign_placed = true;
                                 } else {
                                     eprintln!(
-                                        "  Skipping sign for '{name}' at ({sign_x}, {sign_z}); out of bounds x:[{min_x},{max_x}] z:[{min_z},{max_z}]"
+                                        "  Skipping sign for '{name}' at ({sign_x}, {sign_y}, {sign_z}); out of bounds x:[{min_x},{max_x}] z:[{min_z},{max_z}]"
                                     );
                                 }
                                 distance_since_sign = 0.0;
@@ -391,16 +392,16 @@ pub fn generate_highways(editor: &mut WorldEditor, element: &ProcessedElement, a
                         let sign_z = start.z + side_dz * (block_range + 1);
                         let (min_x, min_z) = editor.get_min_coords();
                         let (max_x, max_z) = editor.get_max_coords();
-                        if sign_x >= min_x && sign_x <= max_x && sign_z >= min_z && sign_z <= max_z
-                        {
+                        let sign_y = editor.get_absolute_y(sign_x, 1, sign_z);
+                        if sign_x >= min_x && sign_x <= max_x && sign_z >= min_z && sign_z <= max_z {
                             eprintln!(
-                                "  Fallback placing sign for '{name}' at ({sign_x}, {sign_z})"
+                                "  Fallback placing sign for '{name}' at ({sign_x}, {sign_y}, {sign_z})"
                             );
                             let (l1, l2, l3, l4) = format_sign_text(name);
                             editor.set_sign(l1, l2, l3, l4, sign_x, 1, sign_z, rotation);
                         } else {
                             eprintln!(
-                                "  Fallback sign for '{name}' out of bounds at ({sign_x}, {sign_z})"
+                                "  Fallback sign for '{name}' out of bounds at ({sign_x}, {sign_y}, {sign_z})"
                             );
                         }
                     }

--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -487,6 +487,9 @@ impl<'a> WorldEditor<'a> {
         // overriding any existing block, which is necessary because signs
         // are typically placed next to roads where terrain or vegetation
         // might have been generated earlier.
+        if !self.block_at(x, y - 1, z) {
+            self.set_block(DIRT, x, y - 1, z, None, Some(&[]));
+        }
         self.set_block_with_properties(sign_block, x, y, z, None, Some(&[]));
     }
 


### PR DESCRIPTION
## Summary
- Log y-coordinate when attempting and placing highway name signs
- Ensure signs stand on a solid block by filling empty ground beneath

## Testing
- `cargo test` *(fails: error sending request for URL; unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68c49e9200d8832f8d06a3d099c1e2f9