### PR TITLE
Remove unused set_block_with_properties

### DIFF
--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -591,49 +591,6 @@ impl<'a> WorldEditor<'a> {
         }
     }
 
-    /// Sets a block with properties at the given coordinates.
-    /// Y value is interpreted as an offset from ground level.
-    #[inline]
-    pub fn set_block_with_properties(
-        &mut self,
-        block_with_props: BlockWithProperties,
-        x: i32,
-        y: i32,
-        z: i32,
-        override_whitelist: Option<&[Block]>,
-        override_blacklist: Option<&[Block]>,
-    ) {
-        // Check if coordinates are within bounds
-        if !self.xzbbox.contains(&XZPoint::new(x, z)) {
-            return;
-        }
-
-        // Calculate the absolute Y coordinate based on ground level
-        let absolute_y = self.get_absolute_y(x, y, z);
-
-        let should_insert = if let Some(existing_block) = self.world.get_block(x, absolute_y, z) {
-            // Check against whitelist and blacklist
-            if let Some(whitelist) = override_whitelist {
-                whitelist
-                    .iter()
-                    .any(|whitelisted_block: &Block| whitelisted_block.id() == existing_block.id())
-            } else if let Some(blacklist) = override_blacklist {
-                !blacklist
-                    .iter()
-                    .any(|blacklisted_block: &Block| blacklisted_block.id() == existing_block.id())
-            } else {
-                false
-            }
-        } else {
-            true
-        };
-
-        if should_insert {
-            self.world
-                .set_block_with_properties(x, absolute_y, z, block_with_props);
-        }
-    }
-
     /// Sets a block with properties at the given coordinates with absolute Y value.
     #[inline]
     pub fn set_block_with_properties_absolute(


### PR DESCRIPTION
## Summary
- remove unused `set_block_with_properties` method from `WorldEditor`

## Testing
- `cargo check --all-targets --all-features`


------
https://chatgpt.com/codex/tasks/task_e_68c4bc4f2aac832f883ac7b974af48be