### PR TITLE
Use direct Block comparisons in world editor

### DIFF
--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -534,13 +534,9 @@ impl<'a> WorldEditor<'a> {
         let should_insert = if let Some(existing_block) = self.world.get_block(x, absolute_y, z) {
             // Check against whitelist and blacklist
             if let Some(whitelist) = override_whitelist {
-                whitelist
-                    .iter()
-                    .any(|whitelisted_block: &Block| whitelisted_block.name() == existing_block.name())
+                whitelist.iter().any(|whitelisted_block: &Block| *whitelisted_block == existing_block)
             } else if let Some(blacklist) = override_blacklist {
-                !blacklist
-                    .iter()
-                    .any(|blacklisted_block: &Block| blacklisted_block.name() == existing_block.name())
+                !blacklist.iter().any(|blacklisted_block: &Block| *blacklisted_block == existing_block)
             } else {
                 false
             }
@@ -572,13 +568,9 @@ impl<'a> WorldEditor<'a> {
         let should_insert = if let Some(existing_block) = self.world.get_block(x, absolute_y, z) {
             // Check against whitelist and blacklist
             if let Some(whitelist) = override_whitelist {
-                whitelist
-                    .iter()
-                    .any(|whitelisted_block: &Block| whitelisted_block.name() == existing_block.name())
+                whitelist.iter().any(|whitelisted_block: &Block| *whitelisted_block == existing_block)
             } else if let Some(blacklist) = override_blacklist {
-                !blacklist
-                    .iter()
-                    .any(|blacklisted_block: &Block| blacklisted_block.name() == existing_block.name())
+                !blacklist.iter().any(|blacklisted_block: &Block| *blacklisted_block == existing_block)
             } else {
                 false
             }
@@ -610,13 +602,9 @@ impl<'a> WorldEditor<'a> {
         let should_insert = if let Some(existing_block) = self.world.get_block(x, absolute_y, z) {
             // Check against whitelist and blacklist
             if let Some(whitelist) = override_whitelist {
-                whitelist
-                    .iter()
-                    .any(|whitelisted_block: &Block| whitelisted_block.name() == existing_block.name())
+                whitelist.iter().any(|whitelisted_block: &Block| *whitelisted_block == existing_block)
             } else if let Some(blacklist) = override_blacklist {
-                !blacklist
-                    .iter()
-                    .any(|blacklisted_block: &Block| blacklisted_block.name() == existing_block.name())
+                !blacklist.iter().any(|blacklisted_block: &Block| *blacklisted_block == existing_block)
             } else {
                 false
             }
@@ -712,10 +700,7 @@ impl<'a> WorldEditor<'a> {
         // Retrieve the chunk modification map
         if let Some(existing_block) = self.world.get_block(x, absolute_y, z) {
             if let Some(whitelist) = whitelist {
-                if whitelist
-                    .iter()
-                    .any(|whitelisted_block: &Block| whitelisted_block.name() == existing_block.name())
-                {
+                if whitelist.iter().any(|whitelisted_block: &Block| *whitelisted_block == existing_block) {
                     return true; // Block is in the list
                 }
             }
@@ -737,19 +722,13 @@ impl<'a> WorldEditor<'a> {
         if let Some(existing_block) = self.world.get_block(x, absolute_y, z) {
             // Check against whitelist and blacklist
             if let Some(whitelist) = whitelist {
-                if whitelist
-                    .iter()
-                    .any(|whitelisted_block: &Block| whitelisted_block.name() == existing_block.name())
-                {
+                if whitelist.iter().any(|whitelisted_block: &Block| *whitelisted_block == existing_block) {
                     return true; // Block is in whitelist
                 }
                 return false;
             }
             if let Some(blacklist) = blacklist {
-                if blacklist
-                    .iter()
-                    .any(|blacklisted_block: &Block| blacklisted_block.name() == existing_block.name())
-                {
+                if blacklist.iter().any(|blacklisted_block: &Block| *blacklisted_block == existing_block) {
                     return true; // Block is in blacklist
                 }
             }


### PR DESCRIPTION
## Summary
- replace block id/name comparisons with direct `Block` equality in world editor routines

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c50272be14832f803d48e07854e977