### PR TITLE
Store fully qualified block names and verify palette output

### DIFF
--- a/src/block_definitions.rs
+++ b/src/block_definitions.rs
@@ -82,8 +82,11 @@ impl BlockWithProperties {
 
 impl Block {
     #[inline(always)]
-    const fn new(name: &'static str) -> Self {
-        Self { name }
+    const fn new(namespaced_name: &'static str) -> Self {
+        // Names are expected to include the namespace, e.g. "minecraft:oak_planks"
+        Self {
+            name: namespaced_name,
+        }
     }
 
     #[inline(always)]
@@ -674,4 +677,20 @@ pub fn get_castle_wall_block() -> Block {
         BRICK,
     ];
     castle_wall_options[rng.gen_range(0..castle_wall_options.len())]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_new_stores_namespace_qualified_name() {
+        let block = Block::new("minecraft:oak_planks");
+        assert_eq!(block.name(), "minecraft:oak_planks");
+    }
+
+    #[test]
+    fn block_constant_returns_namespaced_name() {
+        assert_eq!(OAK_PLANKS.name(), "minecraft:oak_planks");
+    }
 }

--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -534,9 +534,13 @@ impl<'a> WorldEditor<'a> {
         let should_insert = if let Some(existing_block) = self.world.get_block(x, absolute_y, z) {
             // Check against whitelist and blacklist
             if let Some(whitelist) = override_whitelist {
-                whitelist.iter().any(|whitelisted_block: &Block| *whitelisted_block == existing_block)
+                whitelist
+                    .iter()
+                    .any(|whitelisted_block: &Block| *whitelisted_block == existing_block)
             } else if let Some(blacklist) = override_blacklist {
-                !blacklist.iter().any(|blacklisted_block: &Block| *blacklisted_block == existing_block)
+                !blacklist
+                    .iter()
+                    .any(|blacklisted_block: &Block| *blacklisted_block == existing_block)
             } else {
                 false
             }
@@ -568,9 +572,13 @@ impl<'a> WorldEditor<'a> {
         let should_insert = if let Some(existing_block) = self.world.get_block(x, absolute_y, z) {
             // Check against whitelist and blacklist
             if let Some(whitelist) = override_whitelist {
-                whitelist.iter().any(|whitelisted_block: &Block| *whitelisted_block == existing_block)
+                whitelist
+                    .iter()
+                    .any(|whitelisted_block: &Block| *whitelisted_block == existing_block)
             } else if let Some(blacklist) = override_blacklist {
-                !blacklist.iter().any(|blacklisted_block: &Block| *blacklisted_block == existing_block)
+                !blacklist
+                    .iter()
+                    .any(|blacklisted_block: &Block| *blacklisted_block == existing_block)
             } else {
                 false
             }
@@ -602,9 +610,13 @@ impl<'a> WorldEditor<'a> {
         let should_insert = if let Some(existing_block) = self.world.get_block(x, absolute_y, z) {
             // Check against whitelist and blacklist
             if let Some(whitelist) = override_whitelist {
-                whitelist.iter().any(|whitelisted_block: &Block| *whitelisted_block == existing_block)
+                whitelist
+                    .iter()
+                    .any(|whitelisted_block: &Block| *whitelisted_block == existing_block)
             } else if let Some(blacklist) = override_blacklist {
-                !blacklist.iter().any(|blacklisted_block: &Block| *blacklisted_block == existing_block)
+                !blacklist
+                    .iter()
+                    .any(|blacklisted_block: &Block| *blacklisted_block == existing_block)
             } else {
                 false
             }
@@ -700,7 +712,10 @@ impl<'a> WorldEditor<'a> {
         // Retrieve the chunk modification map
         if let Some(existing_block) = self.world.get_block(x, absolute_y, z) {
             if let Some(whitelist) = whitelist {
-                if whitelist.iter().any(|whitelisted_block: &Block| *whitelisted_block == existing_block) {
+                if whitelist
+                    .iter()
+                    .any(|whitelisted_block: &Block| *whitelisted_block == existing_block)
+                {
                     return true; // Block is in the list
                 }
             }
@@ -722,13 +737,19 @@ impl<'a> WorldEditor<'a> {
         if let Some(existing_block) = self.world.get_block(x, absolute_y, z) {
             // Check against whitelist and blacklist
             if let Some(whitelist) = whitelist {
-                if whitelist.iter().any(|whitelisted_block: &Block| *whitelisted_block == existing_block) {
+                if whitelist
+                    .iter()
+                    .any(|whitelisted_block: &Block| *whitelisted_block == existing_block)
+                {
                     return true; // Block is in whitelist
                 }
                 return false;
             }
             if let Some(blacklist) = blacklist {
-                if blacklist.iter().any(|blacklisted_block: &Block| *blacklisted_block == existing_block) {
+                if blacklist
+                    .iter()
+                    .any(|blacklisted_block: &Block| *blacklisted_block == existing_block)
+                {
                     return true; // Block is in blacklist
                 }
             }
@@ -1093,5 +1114,20 @@ mod tests {
         assert_eq!(l2, "0123456789abcde");
         assert_eq!(l3, "0123456789abcde");
         assert_eq!(l4, "0123456789abcde");
+    }
+
+    #[test]
+    fn palette_item_contains_namespaced_names() {
+        use crate::block_definitions::OAK_PLANKS;
+
+        let mut section = SectionToModify::default();
+        section.set_block(0, 0, 0, OAK_PLANKS);
+
+        let nbt_section = section.to_section(0);
+        assert!(nbt_section
+            .block_states
+            .palette
+            .iter()
+            .any(|p| p.name == "minecraft:oak_planks"));
     }
 }


### PR DESCRIPTION
## Summary
- Store namespace-qualified identifiers in `Block` and expose them via `block.name()`
- Confirm palette generation uses `block.name()` values so entries like `minecraft:oak_planks` appear
- Add unit tests for block naming and palette output

## Testing
- `cargo test --no-default-features`


------
https://chatgpt.com/codex/tasks/task_e_68c5051915ec832f9faf46a7a1a68e1f