### PR TITLE
Add constructor for blocks from strings

### DIFF
--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -897,6 +897,14 @@ impl<'a> WorldEditor<'a> {
                             }
                         };
 
+                        // Normalize palette block names from NBT
+                        for section in &mut chunk.sections {
+                            for palette_item in &mut section.block_states.palette {
+                                palette_item.name =
+                                    Block::from_str(&palette_item.name).name().to_string();
+                            }
+                        }
+
                         // Update sections while preserving existing data
                         let new_sections: Vec<Section> = chunk_to_modify.sections().collect();
                         for new_section in new_sections {


### PR DESCRIPTION
## Summary
- allow creating `Block` from arbitrary names via `Block::from_str`
- canonicalize block names from existing chunk NBT using `Block::from_str`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c56d57dd50832fa86de6b8ace2572c