### PR TITLE
Refactor sign placement to use default properties

### DIFF
--- a/src/block_definitions.rs
+++ b/src/block_definitions.rs
@@ -95,6 +95,13 @@ impl Block {
         self.name
     }
 
+    /// Returns the canonical default properties for this block, if any.
+    ///
+    /// These defaults represent the block's standard state in Minecraft and
+    /// are used throughout the codebase as the baseline configuration. Using
+    /// them ensures consistent behaviour, for example when placing signs whose
+    /// rotation and waterlogged state start from these defaults before
+    /// applying overrides.
     pub fn properties(&self) -> Option<Value> {
         match self.name {
             "minecraft:birch_leaves" => Some(Value::Compound({

--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -495,19 +495,11 @@ impl<'a> WorldEditor<'a> {
 
         let rotation = rotation.clamp(0, 15);
 
-        // Start from the default sign properties (which include default
-        // rotation and waterlogged state) and override the rotation.
-        let mut sign_properties = match SIGN.properties() {
-            Some(Value::Compound(map)) => map,
-            _ => HashMap::new(),
-        };
-        sign_properties.insert(
-            "rotation".to_string(),
-            Value::String(rotation.to_string()),
-        );
-
-        let sign_block =
-            BlockWithProperties::new(SIGN, Some(Value::Compound(sign_properties)));
+        // Start from the default sign properties and override the rotation.
+        let mut sign_block = BlockWithProperties::new(SIGN, SIGN.properties());
+        if let Some(Value::Compound(ref mut props)) = sign_block.properties.as_mut() {
+            props.insert("rotation".to_string(), Value::String(rotation.to_string()));
+        }
 
         // Ensure that the sign is always placed even if another block
         // already occupies the target position. An empty blacklist allows
@@ -1176,7 +1168,10 @@ mod tests {
         match &sign_palette.properties {
             Some(Value::Compound(map)) => {
                 assert_eq!(map.get("rotation"), Some(&Value::String("4".to_string())));
-                assert_eq!(map.get("waterlogged"), Some(&Value::String("false".to_string())));
+                assert_eq!(
+                    map.get("waterlogged"),
+                    Some(&Value::String("false".to_string()))
+                );
             }
             _ => panic!("sign properties missing"),
         }


### PR DESCRIPTION
## Summary
- Start signs from the canonical defaults via `BlockWithProperties::new(SIGN, SIGN.properties())`
- Override rotation on the default sign property map
- Document that `Block::properties()` returns canonical defaults for consistent sign behavior

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c57f259660832fbfc454a92b3b2da9