### PR TITLE
Explicitly set sign block properties

### DIFF
--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -204,7 +204,7 @@ pub fn generate_world(
     // Set sign for player orientation
     let (line1, line2, line3, line4) = format_sign_text("↑\nGenerated World\nThis direction\n");
     let sign_y = editor.get_absolute_y(9, -61, 9);
-    editor.set_sign(line1, line2, line3, line4, 9, sign_y, 9, 6);
+    editor.set_sign(line1, line2, line3, line4, 9, sign_y, 9);
 
     ground_pb.inc(block_counter % batch_size);
     ground_pb.finish();

--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -324,14 +324,6 @@ pub fn generate_highways(editor: &mut WorldEditor, element: &ProcessedElement, a
                     if let Some(start) = prev_node {
                         let dx_seg = node.x - start.x;
                         let dz_seg = node.z - start.z;
-                        let mut rotation = (((dz_seg as f64).atan2(dx_seg as f64)
-                            / (2.0 * std::f64::consts::PI))
-                            * 16.0)
-                            .round() as i8;
-                        if rotation < 0 {
-                            rotation += 16;
-                        }
-
                         let side_dx = -dz_seg.signum();
                         let side_dz = dx_seg.signum();
 
@@ -349,7 +341,7 @@ pub fn generate_highways(editor: &mut WorldEditor, element: &ProcessedElement, a
                                 let (max_x, max_z) = editor.get_max_coords();
                                 let sign_y = editor.get_absolute_y(sign_x, 1, sign_z);
                                 eprintln!(
-                                    "  Attempting sign for '{name}' at ({sign_x}, {sign_y}, {sign_z}) with rotation {rotation}"
+                                    "  Attempting sign for '{name}' at ({sign_x}, {sign_y}, {sign_z})"
                                 );
                                 if sign_x >= min_x
                                     && sign_x <= max_x
@@ -360,8 +352,7 @@ pub fn generate_highways(editor: &mut WorldEditor, element: &ProcessedElement, a
                                         "  Placing sign for '{name}' at ({sign_x}, {sign_y}, {sign_z})"
                                     );
                                     let (l1, l2, l3, l4) = format_sign_text(name);
-                                    editor
-                                        .set_sign(l1, l2, l3, l4, sign_x, sign_y, sign_z, rotation);
+                                    editor.set_sign(l1, l2, l3, l4, sign_x, sign_y, sign_z);
                                     sign_placed = true;
                                 } else {
                                     eprintln!(
@@ -380,13 +371,6 @@ pub fn generate_highways(editor: &mut WorldEditor, element: &ProcessedElement, a
                     if let (Some(start), Some(next)) = (way.nodes.first(), way.nodes.get(1)) {
                         let dx_seg = next.x - start.x;
                         let dz_seg = next.z - start.z;
-                        let mut rotation = (((dz_seg as f64).atan2(dx_seg as f64)
-                            / (2.0 * std::f64::consts::PI))
-                            * 16.0)
-                            .round() as i8;
-                        if rotation < 0 {
-                            rotation += 16;
-                        }
                         let side_dx = -dz_seg.signum();
                         let side_dz = dx_seg.signum();
                         let sign_x = start.x + side_dx * (block_range + 1);
@@ -400,7 +384,7 @@ pub fn generate_highways(editor: &mut WorldEditor, element: &ProcessedElement, a
                                 "  Fallback placing sign for '{name}' at ({sign_x}, {sign_y}, {sign_z})"
                             );
                             let (l1, l2, l3, l4) = format_sign_text(name);
-                            editor.set_sign(l1, l2, l3, l4, sign_x, sign_y, sign_z, rotation);
+                            editor.set_sign(l1, l2, l3, l4, sign_x, sign_y, sign_z);
                         } else {
                             eprintln!(
                                 "  Fallback sign for '{name}' out of bounds at ({sign_x}, {sign_y}, {sign_z})"

--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -430,7 +430,6 @@ impl<'a> WorldEditor<'a> {
         x: i32,
         y: i32,
         z: i32,
-        rotation: i8,
     ) {
         let absolute_y = y;
         let chunk_x = x >> 4;
@@ -493,13 +492,14 @@ impl<'a> WorldEditor<'a> {
             );
         }
 
-        let rotation = rotation.clamp(0, 15);
-
-        // Start from the default sign properties and override the rotation.
-        let mut sign_block = BlockWithProperties::new(SIGN, SIGN.properties());
-        if let Some(Value::Compound(ref mut props)) = sign_block.properties.as_mut() {
-            props.insert("rotation".to_string(), Value::String(rotation.to_string()));
-        }
+        // Explicitly set all sign properties.
+        let mut props = HashMap::new();
+        props.insert("rotation".to_string(), Value::String("0".to_string()));
+        props.insert(
+            "waterlogged".to_string(),
+            Value::String("false".to_string()),
+        );
+        let sign_block = BlockWithProperties::new(SIGN, Some(Value::Compound(props)));
 
         // Ensure that the sign is always placed even if another block
         // already occupies the target position. An empty blacklist allows


### PR DESCRIPTION
## Summary
- Explicitly set rotation and waterlogged properties when placing signs
- Remove rotation argument and orientation math from highway sign placement
- Update call sites for new sign API

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c589789b68832f8fb339ec3c1ebc75