### PR TITLE
Fix merge conflict markers in rust sources

### DIFF
--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -4,12 +4,8 @@ use crate::bresenham::bresenham_line;
 use crate::coordinate_system::cartesian::XZPoint;
 use crate::floodfill::flood_fill_area;
 use crate::osm_parser::{ProcessedElement, ProcessedWay};
-<<<<<<< HEAD
-use crate::world_editor::WorldEditor;
-use std::collections::HashMap;
-=======
 use crate::world_editor::{format_sign_text, WorldEditor};
->>>>>>> street-signs
+use std::collections::HashMap;
 
 /// Generates highways with elevation support based on layer tags and connectivity analysis
 pub fn generate_highways(
@@ -741,13 +737,14 @@ mod tests {
         let tmp = tempdir().unwrap();
         let region_dir = tmp.path().join("region");
         std::fs::create_dir(&region_dir).unwrap();
-        let mut editor = WorldEditor::new(region_dir.to_str().unwrap(), &bbox);
+        let llbbox = LLBBox::new(0., 0., 1., 1.).unwrap();
+        let mut editor = WorldEditor::new(region_dir.clone(), &bbox, llbbox.clone());
 
         let args = Args {
-            bbox: LLBBox::new(0., 0., 1., 1.).unwrap(),
+            bbox: llbbox,
             file: None,
             save_json_file: None,
-            path: tmp.path().to_str().unwrap().to_string(),
+            path: tmp.path().to_path_buf(),
             downloader: "requests".to_string(),
             scale: 1.0,
             ground_level: -62,
@@ -780,7 +777,8 @@ mod tests {
         let way = ProcessedWay { id: 1, nodes, tags };
         let element = ProcessedElement::Way(way);
 
-        generate_highways(&mut editor, &element, &args);
+        let all = [element.clone()];
+        generate_highways(&mut editor, &element, &args, &all);
 
         for x in [200, 400, 600, 800, 1000] {
             assert!(editor.check_for_block(x, 1, 6, Some(&[SIGN])));
@@ -794,13 +792,14 @@ mod tests {
         let tmp = tempdir().unwrap();
         let region_dir = tmp.path().join("region");
         std::fs::create_dir(&region_dir).unwrap();
-        let mut editor = WorldEditor::new(region_dir.to_str().unwrap(), &bbox);
+        let llbbox = LLBBox::new(0., 0., 1., 1.).unwrap();
+        let mut editor = WorldEditor::new(region_dir.clone(), &bbox, llbbox.clone());
 
         let args = Args {
-            bbox: LLBBox::new(0., 0., 1., 1.).unwrap(),
+            bbox: llbbox,
             file: None,
             save_json_file: None,
-            path: tmp.path().to_str().unwrap().to_string(),
+            path: tmp.path().to_path_buf(),
             downloader: "requests".to_string(),
             scale: 1.0,
             ground_level: -62,
@@ -833,7 +832,8 @@ mod tests {
         let way = ProcessedWay { id: 1, nodes, tags };
         let element = ProcessedElement::Way(way);
 
-        generate_highways(&mut editor, &element, &args);
+        let all = [element.clone()];
+        generate_highways(&mut editor, &element, &args, &all);
 
         let mut found = false;
         for x in 0..=100 {

--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -814,10 +814,6 @@ impl<'a> WorldEditor<'a> {
             other: chunk.other,
         };
 
-<<<<<<< HEAD
-        // Create the Level wrapper
-        let level_data = create_level_wrapper(&chunk_data);
-=======
         // Build the root NBT structure for the chunk
         let sections = Value::List(
             chunk_data
@@ -868,7 +864,6 @@ impl<'a> WorldEditor<'a> {
                 })
                 .collect(),
         );
->>>>>>> street-signs
 
         let mut root = HashMap::from([
             ("DataVersion".to_string(), Value::Int(DATA_VERSION)),
@@ -1120,25 +1115,6 @@ fn get_entity_coords(entity: &HashMap<String, Value>) -> (i32, i32, i32) {
 }
 
 fn create_level_wrapper(chunk: &Chunk) -> HashMap<String, Value> {
-<<<<<<< HEAD
-    HashMap::from([(
-        "Level".to_string(),
-        Value::Compound(HashMap::from([
-            ("xPos".to_string(), Value::Int(chunk.x_pos)),
-            ("zPos".to_string(), Value::Int(chunk.z_pos)),
-            (
-                "isLightOn".to_string(),
-                Value::Byte(i8::try_from(chunk.is_light_on).unwrap()),
-            ),
-            (
-                "sections".to_string(),
-                Value::List(
-                    chunk
-                        .sections
-                        .iter()
-                        .map(|section| {
-                            let mut block_states = HashMap::from([(
-=======
     let sections = Value::List(
         chunk
             .sections
@@ -1150,7 +1126,6 @@ fn create_level_wrapper(chunk: &Chunk) -> HashMap<String, Value> {
                         "block_states".to_string(),
                         Value::Compound(HashMap::from([
                             (
->>>>>>> street-signs
                                 "palette".to_string(),
                                 Value::List(
                                     section
@@ -1172,31 +1147,6 @@ fn create_level_wrapper(chunk: &Chunk) -> HashMap<String, Value> {
                                         })
                                         .collect(),
                                 ),
-<<<<<<< HEAD
-                            )]);
-
-                            // only add the `data` attribute if it's non-empty
-                            // some software (cough cough dynmap) chokes otherwise
-                            if let Some(data) = &section.block_states.data {
-                                if !data.is_empty() {
-                                    block_states.insert(
-                                        "data".to_string(),
-                                        Value::LongArray(data.to_owned()),
-                                    );
-                                }
-                            }
-
-                            Value::Compound(HashMap::from([
-                                ("Y".to_string(), Value::Byte(section.y)),
-                                ("block_states".to_string(), Value::Compound(block_states)),
-                            ]))
-                        })
-                        .collect(),
-                ),
-            ),
-        ])),
-    )])
-=======
                             ),
                             (
                                 "data".to_string(),
@@ -1245,8 +1195,7 @@ mod tests {
 
     #[test]
     fn format_sign_text_wraps() {
-        let (l1, l2, l3, l4) =
-            format_sign_text("A very long \"street\" name that needs wrapping");
+        let (l1, l2, l3, l4) = format_sign_text("A very long \"street\" name that needs wrapping");
         assert!(l1.len() <= 15);
         assert!(l2.len() <= 15);
         assert!(l3.len() <= 15);
@@ -1314,5 +1263,4 @@ mod tests {
             _ => panic!("sign properties missing"),
         }
     }
->>>>>>> street-signs
 }


### PR DESCRIPTION
## Summary
- remove leftover merge markers in highways module
- clean up world editor chunk creation after merge
- update highway tests to match new world editor API

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c5e9321190832fb509ee116ecccf25