### PR TITLE
Handle riverbank water areas in relation processing

### DIFF
--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -116,6 +116,9 @@ pub fn generate_world(
                     buildings::generate_building_from_relation(&mut editor, rel, args);
                 } else if rel.tags.contains_key("water")
                     || rel.tags.get("natural") == Some(&"water".to_string())
+                    || rel.tags.get("waterway") == Some(&"riverbank".to_string())
+                    || (rel.tags.get("waterway") == Some(&"river".to_string())
+                        && rel.tags.get("area") == Some(&"yes".to_string()))
                 {
                     water_areas::generate_water_areas(&mut editor, rel);
                 } else if rel.tags.contains_key("natural") {


### PR DESCRIPTION
## Summary
- Recognize water relations tagged with `waterway=riverbank` or `waterway=river` with `area=yes`
- Process riverbank relations in water area generator
- Test that riverbank relations fill polygons with water blocks

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c60cd67104832f84664d2ae309d8d3