### PR TITLE
Compute uniform water level and excavate before filling

### DIFF
--- a/src/ground.rs
+++ b/src/ground.rs
@@ -128,6 +128,21 @@ impl Ground {
     }
 }
 
+#[cfg(test)]
+impl Ground {
+    pub fn from_heights(ground_level: i32, heights: Vec<Vec<i32>>) -> Self {
+        Self {
+            elevation_enabled: true,
+            ground_level,
+            elevation_data: Some(ElevationData {
+                width: heights.first().map(|r| r.len()).unwrap_or(0),
+                height: heights.len(),
+                heights,
+            }),
+        }
+    }
+}
+
 pub fn generate_ground_data(args: &Args) -> Ground {
     if args.terrain {
         println!("{} Fetching elevation...", "[3/7]".bold());

--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -452,6 +452,14 @@ impl<'a> WorldEditor<'a> {
         self.world.get_block(x, absolute_y, z).is_some()
     }
 
+    #[cfg(test)]
+    pub fn get_block_absolute(&self, x: i32, y: i32, z: i32) -> Option<Block> {
+        if !self.xzbbox.contains(&XZPoint::new(x, z)) {
+            return None;
+        }
+        self.world.get_block(x, y, z)
+    }
+
     /// Places a sign at an absolute Y coordinate.
     #[allow(clippy::too_many_arguments, dead_code)]
     pub fn set_sign(


### PR DESCRIPTION
## Summary
- Determine a single water level for each water area based on the minimum terrain height
- Excavate existing blocks to that level and place water uniformly
- Add utilities for test terrain data and retrieving absolute blocks
- Test water level flattening across uneven ground

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c60fe425bc832fb9a86c061dbb7725