### PR TITLE
Infer waterway width from metadata

### DIFF
--- a/src/element_processing/waterways.rs
+++ b/src/element_processing/waterways.rs
@@ -2,20 +2,78 @@ use crate::block_definitions::*;
 use crate::bresenham::bresenham_line;
 use crate::osm_parser::ProcessedWay;
 use crate::world_editor::WorldEditor;
+use std::collections::HashMap;
+
+/// Parse a width string which may contain units and return the width in
+/// Minecraft blocks (approximately meters).
+fn parse_width_to_blocks(width_str: &str) -> Option<i32> {
+    let mut number_part = String::new();
+    let mut unit_part = String::new();
+
+    for c in width_str.trim().chars() {
+        if c.is_ascii_digit() || c == '.' || c == ',' {
+            if c == ',' {
+                number_part.push('.');
+            } else {
+                number_part.push(c);
+            }
+        } else if !c.is_whitespace() {
+            unit_part.push(c.to_ascii_lowercase());
+        }
+    }
+
+    let value: f32 = number_part.parse().ok()?;
+    let meters = if unit_part.contains("ft")
+        || unit_part.contains("foot")
+        || unit_part.contains("feet")
+        || unit_part.contains("'")
+    {
+        value * 0.3048
+    } else if unit_part.contains("km") {
+        value * 1000.0
+    } else {
+        // Default assume meters
+        value
+    };
+
+    Some(meters.round().max(1.0) as i32)
+}
+
+fn infer_width_from_tags(tags: &HashMap<String, String>, default: i32) -> i32 {
+    if let Some(width_str) = tags.get("width") {
+        if let Some(width) = parse_width_to_blocks(width_str) {
+            return width;
+        }
+    }
+
+    // Alternative metadata keys that may specify the width, including data
+    // copied from an associated riverbank polygon.
+    let alternative_keys = [
+        "riverbank:width",
+        "riverbank_width",
+        "est_width",
+        "estimated_width",
+        "avg_width",
+        "average_width",
+        "width:avg",
+        "width:est",
+    ];
+
+    for key in alternative_keys.iter() {
+        if let Some(width_str) = tags.get(*key) {
+            if let Some(width) = parse_width_to_blocks(width_str) {
+                return width;
+            }
+        }
+    }
+
+    default
+}
 
 pub fn generate_waterways(editor: &mut WorldEditor, element: &ProcessedWay) {
     if let Some(waterway_type) = element.tags.get("waterway") {
-        let (mut waterway_width, waterway_depth) = get_waterway_dimensions(waterway_type);
-
-        // Check for custom width in tags
-        if let Some(width_str) = element.tags.get("width") {
-            waterway_width = width_str.parse::<i32>().unwrap_or_else(|_| {
-                width_str
-                    .parse::<f32>()
-                    .map(|f: f32| f as i32)
-                    .unwrap_or(waterway_width)
-            });
-        }
+        let (default_width, waterway_depth) = get_waterway_dimensions(waterway_type);
+        let waterway_width = infer_width_from_tags(&element.tags, default_width);
 
         // Skip layers below the ground level
         if matches!(
@@ -111,5 +169,80 @@ fn create_water_channel(
                 editor.set_block(AIR, x, 1, z, Some(&[GRASS, WHEAT, CARROTS, POTATOES]), None);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordinate_system::cartesian::XZBBox;
+    use crate::coordinate_system::geographic::LLBBox;
+    use crate::osm_parser::ProcessedNode;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn build_way(tags: HashMap<String, String>, nodes: Vec<(i32, i32)>) -> ProcessedWay {
+        let mut processed_nodes = Vec::new();
+        for (i, (x, z)) in nodes.into_iter().enumerate() {
+            processed_nodes.push(ProcessedNode {
+                id: i as u64,
+                tags: HashMap::new(),
+                x,
+                z,
+            });
+        }
+        ProcessedWay {
+            id: 1,
+            nodes: processed_nodes,
+            tags,
+        }
+    }
+
+    #[test]
+    fn width_tag_with_units_is_used() {
+        let xzbbox = XZBBox::rect_from_xz_lengths(120.0, 120.0).unwrap();
+        let llbbox = LLBBox::new(0.0, 0.0, 1.0, 1.0).unwrap();
+        let mut editor = WorldEditor::new(PathBuf::from("test_world"), &xzbbox, llbbox);
+        let tags = HashMap::from([
+            (String::from("waterway"), String::from("river")),
+            (String::from("width"), String::from("30 m")),
+        ]);
+        let way = build_way(tags, vec![(50, 20), (50, 80)]);
+        generate_waterways(&mut editor, &way);
+
+        // width 30 -> half width 15, slopes at 16 -> ensure water within and not beyond
+        assert!(editor.check_for_block(35, 0, 50, Some(&[WATER])));
+        assert!(!editor.check_for_block(67, 0, 50, Some(&[WATER])));
+    }
+
+    #[test]
+    fn infers_width_from_riverbank_metadata() {
+        let xzbbox = XZBBox::rect_from_xz_lengths(120.0, 120.0).unwrap();
+        let llbbox = LLBBox::new(0.0, 0.0, 1.0, 1.0).unwrap();
+        let mut editor = WorldEditor::new(PathBuf::from("test_world"), &xzbbox, llbbox);
+        let tags = HashMap::from([
+            (String::from("waterway"), String::from("river")),
+            (String::from("riverbank:width"), String::from("40")),
+        ]);
+        let way = build_way(tags, vec![(60, 20), (60, 80)]);
+        generate_waterways(&mut editor, &way);
+
+        // width 40 -> half width 20, slopes at 21
+        assert!(editor.check_for_block(40, 0, 50, Some(&[WATER])));
+        assert!(!editor.check_for_block(82, 0, 50, Some(&[WATER])));
+    }
+
+    #[test]
+    fn defaults_when_no_width_metadata() {
+        let xzbbox = XZBBox::rect_from_xz_lengths(120.0, 120.0).unwrap();
+        let llbbox = LLBBox::new(0.0, 0.0, 1.0, 1.0).unwrap();
+        let mut editor = WorldEditor::new(PathBuf::from("test_world"), &xzbbox, llbbox);
+        let tags = HashMap::from([(String::from("waterway"), String::from("river"))]);
+        let way = build_way(tags, vec![(70, 20), (70, 80)]);
+        generate_waterways(&mut editor, &way);
+
+        // default width 8 -> half 4, slopes at 5
+        assert!(editor.check_for_block(66, 0, 50, Some(&[WATER])));
+        assert!(!editor.check_for_block(64, 0, 50, Some(&[WATER])));
     }
 }


### PR DESCRIPTION
## Summary
- parse width strings with units and convert to block counts
- infer waterway width from riverbank or other metadata before falling back to defaults
- test width handling and defaults

## Testing
- `cargo fmt -- --check`
- `cargo test --tests`


------
https://chatgpt.com/codex/tasks/task_e_68c613b3f0a4832f88d2aef6b1515cca