### PR TITLE
Handle coastline and lake water areas

### DIFF
--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -67,12 +67,17 @@ pub fn generate_world(
                     highways::generate_highways(&mut editor, element, args, &elements);
                 } else if way.tags.contains_key("landuse") {
                     landuse::generate_landuse(&mut editor, way, args);
-                } else if way.tags.get("water") == Some(&"river".to_string())
+                } else if way.tags.contains_key("water")
+                    || way.tags.get("natural") == Some(&"water".to_string())
                     || way.tags.get("waterway") == Some(&"riverbank".to_string())
+                    || way.tags.get("water") == Some(&"lake".to_string())
+                    || way.tags.get("water") == Some(&"reservoir".to_string())
                     || (way.tags.get("waterway") == Some(&"river".to_string())
                         && way.tags.get("area") == Some(&"yes".to_string()))
                 {
                     water_areas::generate_water_area_from_way(&mut editor, way);
+                } else if way.tags.get("natural") == Some(&"coastline".to_string()) {
+                    water_areas::generate_coastline_area_from_way(&mut editor, way);
                 } else if way.tags.contains_key("natural") {
                     natural::generate_natural(&mut editor, element, args);
                 } else if way.tags.contains_key("amenity") {
@@ -123,11 +128,14 @@ pub fn generate_world(
                 } else if rel.tags.contains_key("water")
                     || rel.tags.get("natural") == Some(&"water".to_string())
                     || rel.tags.get("waterway") == Some(&"riverbank".to_string())
-                    || rel.tags.get("water") == Some(&"river".to_string())
+                    || rel.tags.get("water") == Some(&"lake".to_string())
+                    || rel.tags.get("water") == Some(&"reservoir".to_string())
                     || (rel.tags.get("waterway") == Some(&"river".to_string())
                         && rel.tags.get("area") == Some(&"yes".to_string()))
                 {
                     water_areas::generate_water_areas(&mut editor, rel);
+                } else if rel.tags.get("natural") == Some(&"coastline".to_string()) {
+                    water_areas::generate_coastline_areas(&mut editor, rel);
                 } else if rel.tags.contains_key("natural") {
                     natural::generate_natural_from_relation(&mut editor, rel, args);
                 } else if rel.tags.contains_key("landuse") {

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -62,6 +62,12 @@ impl Ground {
         coords.map(|c: XZPoint| self.level(c)).max()
     }
 
+    /// Returns the configured ground level regardless of elevation data
+    #[inline(always)]
+    pub fn ground_level(&self) -> i32 {
+        self.ground_level
+    }
+
     /// Converts game coordinates to elevation data coordinates
     #[inline(always)]
     fn get_data_coordinates(&self, coord: XZPoint, data: &ElevationData) -> (f64, f64) {

--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -401,6 +401,12 @@ impl<'a> WorldEditor<'a> {
         self.ground.as_ref().map(|g| g.as_ref())
     }
 
+    /// Returns the default ground level configured for the world
+    #[inline(always)]
+    pub fn ground_level(&self) -> i32 {
+        self.ground.as_ref().map(|g| g.ground_level()).unwrap_or(0)
+    }
+
     /// Calculate the absolute Y position from a ground-relative offset
     #[inline(always)]
     pub fn get_absolute_y(&self, x: i32, y_offset: i32, z: i32) -> i32 {


### PR DESCRIPTION
## Summary
- detect lakes and reservoirs tagged as `natural=water`, `water=lake`, or `water=reservoir`
- add support for `natural=coastline` by filling outside the land polygon
- derive water height from ground data when available

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c6211af534832f8b34fe402e179a8e