### PR TITLE
Document AIR_ID constant and usage

### DIFF
--- a/src/block_registry.rs
+++ b/src/block_registry.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 use crate::block_definitions::Block;
 use crate::block_definitions::*;
 
+/// Numeric identifier for the `AIR` block used inside block ID arrays.
 pub const AIR_ID: u16 = 0;
 
 struct Registry {

--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -102,6 +102,7 @@ struct PaletteItem {
 }
 
 struct SectionToModify {
+    /// Block IDs for a 16×16×16 section, using `AIR_ID` for empty blocks.
     block_ids: [u16; 4096],
     // Store properties for blocks that have them, indexed by the same index as blocks array
     properties: FnvHashMap<usize, Value>,


### PR DESCRIPTION
## Summary
- clarify AIR_ID purpose in block registry
- note AIR_ID usage for empty positions in SectionToModify

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c746039170832fbdedabfd8fff88fa