### PR TITLE
Document block registry and memory optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Additionally, you can customize various generation settings, such as world scale
 
 Full documentation is available in the [GitHub Wiki](https://github.com/louis-e/arnis/wiki/), covering topics such as technical explanations, FAQs, contribution guidelines and roadmaps.
 
+## 🧱 Block ID Registry
+
+Arnis maintains a central registry that assigns a compact `u16` identifier to
+every block type. World sections reference blocks by these numeric IDs instead
+of storing the full `Block` structures. Because a `Block` is 16 bytes while an
+ID is only two bytes, this reduces the memory needed for block storage by
+roughly 8×.
+
 ## :trophy: Open Source
 #### Key objectives of this project
 - **Modularity**: Ensure that all components (e.g., data fetching, processing, and world generation) are cleanly separated into distinct modules for better maintainability and scalability.

--- a/src/block_registry.rs
+++ b/src/block_registry.rs
@@ -1,3 +1,11 @@
+//! Maintains a bidirectional mapping between [`Block`] values and compact
+//! `u16` identifiers used throughout the world editor.
+//!
+//! Storing numeric IDs instead of full 16-byte [`Block`] structs lets chunk
+//! sections represent blocks using just two bytes each, yielding an
+//! approximately eightfold reduction in memory usage while still allowing fast
+//! lookups in both directions.
+
 use fnv::FnvHashMap;
 use once_cell::sync::Lazy;
 use std::sync::Mutex;

--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -101,8 +101,14 @@ struct PaletteItem {
     properties: Option<Value>,
 }
 
+/// Mutable representation of a 16×16×16 chunk section.
+///
+/// Each entry stores a `u16` identifier from the global block registry rather
+/// than a full [`Block`] struct. Using registry IDs keeps the block array
+/// compact—two bytes per block instead of sixteen—providing roughly an
+/// eightfold memory reduction.
 struct SectionToModify {
-    /// Block IDs for a 16×16×16 section, using `AIR_ID` for empty blocks.
+    /// Registry `u16` block IDs for a 16×16×16 section, using `AIR_ID` for empty blocks.
     block_ids: [u16; 4096],
     // Store properties for blocks that have them, indexed by the same index as blocks array
     properties: FnvHashMap<usize, Value>,
@@ -148,8 +154,7 @@ impl SectionToModify {
     fn to_section(&self, y: i8) -> Section {
         // Create a map of unique block+properties combinations to palette indices
         let mut unique_blocks: Vec<(u16, Block, Option<Value>)> = Vec::new();
-        let mut palette_lookup: FnvHashMap<(u16, Option<String>), usize> =
-            FnvHashMap::default();
+        let mut palette_lookup: FnvHashMap<(u16, Option<String>), usize> = FnvHashMap::default();
 
         // Build unique block combinations and lookup table
         for (i, &block_id) in self.block_ids.iter().enumerate() {


### PR DESCRIPTION
## Summary
- explain block ID registry and 8× block-array memory savings in README
- add module-level docs for block registry implementation
- document memory rationale in `SectionToModify`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c74e141750832f8c144b2ad172ce5b