### PR TITLE
Add block registry stability tests

### DIFF
--- a/tests/block_registry.rs
+++ b/tests/block_registry.rs
@@ -1,0 +1,34 @@
+#[path = "../src/colors.rs"]
+mod colors;
+#[path = "../src/block_definitions.rs"]
+mod block_definitions;
+#[path = "../src/block_registry.rs"]
+mod block_registry;
+
+use block_definitions::*;
+use block_registry::*;
+
+#[test]
+fn known_blocks_have_stable_ids() {
+    assert_eq!(id(AIR), AIR_ID);
+    assert_eq!(id(STONE), 84);
+    assert_eq!(id(WATER), 87);
+}
+
+#[test]
+fn id_inserts_once_and_is_consistent() {
+    let custom_name = "minecraft:__block_registry_test";
+    let first_id = id(Block::from_str(custom_name));
+    let second_id = id(Block::from_str(custom_name));
+    assert_eq!(first_id, second_id);
+
+    let other_id = id(Block::from_str("minecraft:__block_registry_other_test"));
+    assert_eq!(other_id, first_id + 1);
+}
+
+#[test]
+fn block_returns_original() {
+    let custom = Block::from_str("minecraft:__block_registry_block_test");
+    let id = id(custom);
+    assert_eq!(block(id), custom);
+}


### PR DESCRIPTION
## Summary
- test block registry for stable IDs and consistent insertion

## Testing
- `cargo test --no-default-features --test block_registry`


------
https://chatgpt.com/codex/tasks/task_e_68c757765ac0832f89b97f652ba0eed6