### PR TITLE
Add biome definitions and registry

### DIFF
--- a/src/biome_definitions.rs
+++ b/src/biome_definitions.rs
@@ -1,0 +1,49 @@
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Debug)]
+pub struct Biome {
+    name: &'static str,
+}
+
+impl Biome {
+    #[inline(always)]
+    const fn new(namespaced_name: &'static str) -> Self {
+        Self {
+            name: namespaced_name,
+        }
+    }
+
+    #[inline(always)]
+    pub fn name(&self) -> &str {
+        self.name
+    }
+
+    pub fn from_str(name: &str) -> Biome {
+        let mut cache = BIOME_NAME_CACHE.lock().unwrap();
+        if let Some(biome) = cache.get(name) {
+            *biome
+        } else {
+            let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
+            let biome = Biome::new(leaked);
+            cache.insert(name.to_string(), biome);
+            biome
+        }
+    }
+}
+
+static BIOME_NAME_CACHE: Lazy<Mutex<HashMap<String, Biome>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+pub const PLAINS: Biome = Biome::new("minecraft:plains");
+pub const FOREST: Biome = Biome::new("minecraft:forest");
+pub const RIVER: Biome = Biome::new("minecraft:river");
+pub const BEACH: Biome = Biome::new("minecraft:beach");
+pub const DESERT: Biome = Biome::new("minecraft:desert");
+pub const OCEAN: Biome = Biome::new("minecraft:ocean");
+pub const JUNGLE: Biome = Biome::new("minecraft:jungle");
+pub const SWAMP: Biome = Biome::new("minecraft:swamp");
+pub const TAIGA: Biome = Biome::new("minecraft:taiga");
+pub const SAVANNA: Biome = Biome::new("minecraft:savanna");
+pub const MOUNTAINS: Biome = Biome::new("minecraft:mountains");

--- a/src/biome_registry.rs
+++ b/src/biome_registry.rs
@@ -1,0 +1,46 @@
+//! Maintains a bidirectional mapping between [`Biome`] values and compact
+//! `u16` identifiers used for referencing biomes.
+
+use fnv::FnvHashMap;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+use crate::biome_definitions::Biome;
+use crate::biome_definitions::*;
+
+struct Registry {
+    biomes: Vec<Biome>,
+    ids: FnvHashMap<Biome, u16>,
+}
+
+static REGISTRY: Lazy<Mutex<Registry>> = Lazy::new(|| {
+    let biomes = vec![
+        PLAINS, FOREST, RIVER, BEACH, DESERT, OCEAN, JUNGLE, SWAMP, TAIGA, SAVANNA, MOUNTAINS,
+    ];
+    let mut ids = FnvHashMap::default();
+    for (id, biome) in biomes.iter().copied().enumerate() {
+        ids.insert(biome, id as u16);
+    }
+    Mutex::new(Registry { biomes, ids })
+});
+
+pub fn id(biome: Biome) -> u16 {
+    let mut registry = REGISTRY.lock().unwrap();
+    if let Some(&id) = registry.ids.get(&biome) {
+        id
+    } else {
+        let id = registry.biomes.len() as u16;
+        registry.biomes.push(biome);
+        registry.ids.insert(biome, id);
+        id
+    }
+}
+
+pub fn biome(id: u16) -> Biome {
+    let registry = REGISTRY.lock().unwrap();
+    registry
+        .biomes
+        .get(id as usize)
+        .copied()
+        .expect("biome id out of range")
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod args;
+mod biome_definitions;
+mod biome_registry;
 mod block_definitions;
 mod block_registry;
 mod bresenham;

--- a/tests/biome_registry.rs
+++ b/tests/biome_registry.rs
@@ -1,0 +1,32 @@
+#[path = "../src/biome_definitions.rs"]
+mod biome_definitions;
+#[path = "../src/biome_registry.rs"]
+mod biome_registry;
+
+use biome_definitions::*;
+use biome_registry::*;
+
+#[test]
+fn known_biomes_have_stable_ids() {
+    assert_eq!(id(PLAINS), 0);
+    assert_eq!(id(FOREST), 1);
+    assert_eq!(id(RIVER), 2);
+}
+
+#[test]
+fn id_inserts_once_and_is_consistent() {
+    let custom_name = "minecraft:__biome_registry_test";
+    let first_id = id(Biome::from_str(custom_name));
+    let second_id = id(Biome::from_str(custom_name));
+    assert_eq!(first_id, second_id);
+
+    let other_id = id(Biome::from_str("minecraft:__biome_registry_other_test"));
+    assert_eq!(other_id, first_id + 1);
+}
+
+#[test]
+fn biome_returns_original() {
+    let custom = Biome::from_str("minecraft:__biome_registry_biome_test");
+    let id = id(custom);
+    assert_eq!(biome(id), custom);
+}


### PR DESCRIPTION
## Summary
- add `Biome` struct with constants for common biomes
- implement `biome_registry` with `id` and `biome` mapping APIs
- include basic tests for `biome_registry`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c78e066ddc832f9eab45a9525d2f60