### PR TITLE
Assign biomes from OSM tags

### DIFF
--- a/src/biomes.rs
+++ b/src/biomes.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+
+use crate::biome_definitions::{Biome, BEACH, FOREST, PLAINS, RIVER};
+
+/// Determines a biome based on OSM-style tag key-value pairs.
+///
+/// Currently supports a handful of common tags with a fallback to
+/// [`PLAINS`] when no specific biome mapping exists.
+pub fn biome_from_tags(tags: &HashMap<String, String>) -> Option<Biome> {
+    if let Some(value) = tags.get("landuse") {
+        if value == "forest" {
+            return Some(FOREST);
+        }
+    }
+
+    if let Some(value) = tags.get("natural") {
+        return match value.as_str() {
+            "water" => Some(RIVER),
+            "beach" => Some(BEACH),
+            _ => Some(PLAINS),
+        };
+    }
+
+    Some(PLAINS)
+}

--- a/src/element_processing/landuse.rs
+++ b/src/element_processing/landuse.rs
@@ -1,4 +1,5 @@
 use crate::args::Args;
+use crate::biomes::biome_from_tags;
 use crate::block_definitions::*;
 use crate::element_processing::tree::Tree;
 use crate::floodfill::flood_fill_area;
@@ -10,6 +11,8 @@ pub fn generate_landuse(editor: &mut WorldEditor, element: &ProcessedWay, args: 
     // Determine block type based on landuse tag
     let binding: String = "".to_string();
     let landuse_tag: &String = element.tags.get("landuse").unwrap_or(&binding);
+
+    let biome = biome_from_tags(&element.tags);
 
     let block_type = match landuse_tag.as_str() {
         "greenfield" | "meadow" | "grass" | "orchard" | "forest" => GRASS_BLOCK,
@@ -51,6 +54,10 @@ pub fn generate_landuse(editor: &mut WorldEditor, element: &ProcessedWay, args: 
     let mut rng: rand::prelude::ThreadRng = rand::thread_rng();
 
     for (x, z) in floor_area {
+        if let Some(b) = biome {
+            editor.set_biome(b, x, 0, z);
+        }
+
         if landuse_tag == "traffic_island" {
             editor.set_block(block_type, x, 1, z, None, None);
         } else if landuse_tag == "construction" || landuse_tag == "railway" {

--- a/src/element_processing/natural.rs
+++ b/src/element_processing/natural.rs
@@ -1,4 +1,5 @@
 use crate::args::Args;
+use crate::biomes::biome_from_tags;
 use crate::block_definitions::*;
 use crate::bresenham::bresenham_line;
 use crate::element_processing::tree::Tree;
@@ -9,6 +10,7 @@ use rand::Rng;
 
 pub fn generate_natural(editor: &mut WorldEditor, element: &ProcessedElement, args: &Args) {
     if let Some(natural_type) = element.tags().get("natural") {
+        let biome = biome_from_tags(element.tags());
         if natural_type == "tree" {
             if let ProcessedElement::Node(node) = element {
                 let x: i32 = node.x;
@@ -59,6 +61,9 @@ pub fn generate_natural(editor: &mut WorldEditor, element: &ProcessedElement, ar
                     let bresenham_points: Vec<(i32, i32, i32)> =
                         bresenham_line(prev.0, 0, prev.1, x, 0, z);
                     for (bx, _, bz) in bresenham_points {
+                        if let Some(b) = biome {
+                            editor.set_biome(b, bx, 0, bz);
+                        }
                         editor.set_block(block_type, bx, 0, bz, None, None);
                     }
 
@@ -82,6 +87,9 @@ pub fn generate_natural(editor: &mut WorldEditor, element: &ProcessedElement, ar
                 let mut rng: rand::prelude::ThreadRng = rand::thread_rng();
 
                 for (x, z) in filled_area {
+                    if let Some(b) = biome {
+                        editor.set_biome(b, x, 0, z);
+                    }
                     editor.set_block(block_type, x, 0, z, None, None);
                     // Generate custom layer instead of dirt, must be stone on the lowest level
                     match natural_type.as_str() {

--- a/src/element_processing/water_areas.rs
+++ b/src/element_processing/water_areas.rs
@@ -7,6 +7,8 @@ use std::time::Instant;
 use crate::bresenham::bresenham_line;
 
 use crate::{
+    biome_definitions::{self, Biome},
+    biomes::biome_from_tags,
     block_definitions::WATER,
     coordinate_system::cartesian::XZPoint,
     osm_parser::{ProcessedMemberRole, ProcessedNode, ProcessedRelation, ProcessedWay},
@@ -21,6 +23,8 @@ fn generate_water_areas_internal(
     fill_outside: bool,
 ) {
     let start_time = Instant::now();
+
+    let biome = biome_from_tags(&element.tags).unwrap_or(biome_definitions::PLAINS);
 
     if !fill_outside {
         let is_water = element.tags.contains_key("water")
@@ -68,7 +72,7 @@ fn generate_water_areas_internal(
         } else {
             0
         };
-        fill_from_barriers(editor, &all_lines, false, water_level);
+        fill_from_barriers(editor, &all_lines, false, water_level, biome);
         return;
     }
 
@@ -92,7 +96,7 @@ fn generate_water_areas_internal(
             } else {
                 0
             };
-            fill_from_barriers(editor, &all_lines, false, water_level);
+            fill_from_barriers(editor, &all_lines, false, water_level, biome);
             return;
         }
 
@@ -108,7 +112,7 @@ fn generate_water_areas_internal(
             } else {
                 0
             };
-            fill_from_barriers(editor, &all_lines, false, water_level);
+            fill_from_barriers(editor, &all_lines, false, water_level, biome);
             return;
         }
 
@@ -192,6 +196,7 @@ fn generate_water_areas_internal(
             editor,
             start_time,
             fill_outside,
+            biome,
         );
     }
 }
@@ -206,6 +211,8 @@ fn generate_water_area_from_way_internal(
     fill_outside: bool,
 ) {
     let start_time = Instant::now();
+
+    let biome = biome_from_tags(&way.tags).unwrap_or(biome_definitions::PLAINS);
 
     if !fill_outside {
         let is_water = way.tags.contains_key("water")
@@ -240,7 +247,13 @@ fn generate_water_area_from_way_internal(
         } else {
             0
         };
-        fill_from_barriers(editor, &[way.nodes.clone()], fill_outside, water_level);
+        fill_from_barriers(
+            editor,
+            &[way.nodes.clone()],
+            fill_outside,
+            water_level,
+            biome,
+        );
         return;
     }
 
@@ -273,6 +286,7 @@ fn generate_water_area_from_way_internal(
         editor,
         start_time,
         fill_outside,
+        biome,
     );
 }
 
@@ -457,6 +471,7 @@ fn fill_from_barriers(
     lines: &[Vec<ProcessedNode>],
     fill_outside: bool,
     water_level: i32,
+    biome: Biome,
 ) {
     let (min_x, min_z) = editor.get_min_coords();
     let (max_x, max_z) = editor.get_max_coords();
@@ -531,6 +546,7 @@ fn fill_from_barriers(
                         });
                         for y in water_level..=terrain {
                             editor.set_block_absolute(WATER, world_x, y, world_z, None, Some(&[]));
+                            editor.set_biome_absolute(biome, world_x, y, world_z);
                         }
                     } else {
                         editor.set_block_absolute(
@@ -541,6 +557,7 @@ fn fill_from_barriers(
                             None,
                             Some(&[]),
                         );
+                        editor.set_biome_absolute(biome, world_x, water_level, world_z);
                     }
                 } else {
                     editor.set_block_absolute(
@@ -551,6 +568,7 @@ fn fill_from_barriers(
                         None,
                         Some(&[]),
                     );
+                    editor.set_biome_absolute(biome, world_x, water_level, world_z);
                 }
             }
         }
@@ -571,7 +589,7 @@ pub fn generate_coastlines(editor: &mut WorldEditor, ways: &[Vec<ProcessedNode>]
     } else {
         0
     };
-    fill_from_barriers(editor, ways, true, level);
+    fill_from_barriers(editor, ways, true, level, biome_definitions::OCEAN);
 }
 
 // Merges ways that share nodes into full loops
@@ -681,6 +699,7 @@ fn inverse_floodfill(
     editor: &mut WorldEditor,
     start_time: Instant,
     fill_outside: bool,
+    biome: Biome,
 ) {
     let inners: Vec<_> = inners
         .into_iter()
@@ -719,6 +738,7 @@ fn inverse_floodfill(
         editor,
         start_time,
         fill_outside,
+        biome,
     );
 }
 
@@ -731,11 +751,21 @@ fn inverse_floodfill_recursive(
     editor: &mut WorldEditor,
     start_time: Instant,
     fill_outside: bool,
+    biome: Biome,
 ) {
     // Check if we've exceeded 25 seconds
     if start_time.elapsed().as_secs() > 25 {
         // Fall back: brute-force fill for the remaining region so we never leave it empty.
-        inverse_floodfill_iterative(min, max, water_level, outers, inners, editor, fill_outside);
+        inverse_floodfill_iterative(
+            min,
+            max,
+            water_level,
+            outers,
+            inners,
+            editor,
+            fill_outside,
+            biome,
+        );
         return;
     }
 
@@ -748,7 +778,16 @@ fn inverse_floodfill_recursive(
     // Multiply as i64 to avoid overflow; in release builds where unchecked math is
     // enabled, this could cause the rest of this code to end up in an infinite loop.
     if ((max.0 - min.0) as i64) * ((max.1 - min.1) as i64) < ITERATIVE_THRES {
-        inverse_floodfill_iterative(min, max, water_level, outers, inners, editor, fill_outside);
+        inverse_floodfill_iterative(
+            min,
+            max,
+            water_level,
+            outers,
+            inners,
+            editor,
+            fill_outside,
+            biome,
+        );
         return;
     }
 
@@ -787,7 +826,7 @@ fn inverse_floodfill_recursive(
                 && outers_intersects.is_empty()
                 && inners_intersects.is_empty())
         {
-            rect_fill(min_x, max_x, min_z, max_z, water_level, editor);
+            rect_fill(min_x, max_x, min_z, max_z, water_level, editor, biome);
             continue;
         }
 
@@ -801,6 +840,7 @@ fn inverse_floodfill_recursive(
                 editor,
                 start_time,
                 fill_outside,
+                biome,
             );
         }
     }
@@ -815,6 +855,7 @@ fn inverse_floodfill_iterative(
     inners: &[Polygon],
     editor: &mut WorldEditor,
     fill_outside: bool,
+    biome: Biome,
 ) {
     let ground = editor.get_ground().cloned();
     let (min_x, min_z) = editor.get_min_coords();
@@ -841,12 +882,15 @@ fn inverse_floodfill_iterative(
                         });
                         for y in water_level..=terrain {
                             editor.set_block_absolute(WATER, x, y, z, None, Some(&[]));
+                            editor.set_biome_absolute(biome, x, y, z);
                         }
                     } else {
                         editor.set_block_absolute(WATER, x, water_level, z, None, Some(&[]));
+                        editor.set_biome_absolute(biome, x, water_level, z);
                     }
                 } else {
                     editor.set_block_absolute(WATER, x, water_level, z, None, Some(&[]));
+                    editor.set_biome_absolute(biome, x, water_level, z);
                 }
             }
         }
@@ -860,6 +904,7 @@ fn rect_fill(
     max_z: i32,
     water_level: i32,
     editor: &mut WorldEditor,
+    biome: Biome,
 ) {
     let ground = editor.get_ground().cloned();
     let (min_x_world, min_z_world) = editor.get_min_coords();
@@ -876,12 +921,15 @@ fn rect_fill(
                     });
                     for y in water_level..=terrain {
                         editor.set_block_absolute(WATER, x, y, z, None, Some(&[]));
+                        editor.set_biome_absolute(biome, x, y, z);
                     }
                 } else {
                     editor.set_block_absolute(WATER, x, water_level, z, None, Some(&[]));
+                    editor.set_biome_absolute(biome, x, water_level, z);
                 }
             } else {
                 editor.set_block_absolute(WATER, x, water_level, z, None, Some(&[]));
+                editor.set_biome_absolute(biome, x, water_level, z);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod args;
 mod biome_definitions;
 mod biome_registry;
+mod biomes;
 mod block_definitions;
 mod block_registry;
 mod bresenham;


### PR DESCRIPTION
## Summary
- add basic OSM tag -> biome mapping
- set biome along with block placement for land use, natural, and water areas
- propagate biomes through flood-fill routines

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c7aad21104832fa58e4c20825161f6