### PR TITLE
Remove compiler warnings

### DIFF
--- a/src/biome_definitions.rs
+++ b/src/biome_definitions.rs
@@ -1,5 +1,8 @@
+#[cfg(test)]
 use once_cell::sync::Lazy;
+#[cfg(test)]
 use std::collections::HashMap;
+#[cfg(test)]
 use std::sync::Mutex;
 
 #[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Debug)]
@@ -20,6 +23,8 @@ impl Biome {
         self.name
     }
 
+    #[cfg(test)]
+    #[allow(dead_code)]
     pub fn from_str(name: &str) -> Biome {
         let mut cache = BIOME_NAME_CACHE.lock().unwrap();
         if let Some(biome) = cache.get(name) {
@@ -33,6 +38,8 @@ impl Biome {
     }
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 static BIOME_NAME_CACHE: Lazy<Mutex<HashMap<String, Biome>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 

--- a/src/element_processing/railways.rs
+++ b/src/element_processing/railways.rs
@@ -60,7 +60,8 @@ pub fn generate_railways(editor: &mut WorldEditor, element: &ProcessedWay) {
                     next.map(|(x, _, z)| (x, z)),
                 );
 
-                if rail_counter % 8 == 7 && matches!(rail_block, RAIL_NORTH_SOUTH | RAIL_EAST_WEST)
+                if rail_counter % 8 == 7
+                    && (rail_block == RAIL_NORTH_SOUTH || rail_block == RAIL_EAST_WEST)
                 {
                     editor.set_block(REDSTONE_BLOCK, bx, 0, bz, None, None);
                     let powered_block = if rail_block == RAIL_NORTH_SOUTH {

--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -511,12 +511,6 @@ impl<'a> WorldEditor<'a> {
         self.ground.as_ref().map(|g| g.as_ref())
     }
 
-    /// Returns the default ground level configured for the world
-    #[inline(always)]
-    pub fn ground_level(&self) -> i32 {
-        self.ground.as_ref().map(|g| g.ground_level()).unwrap_or(0)
-    }
-
     /// Calculate the absolute Y position from a ground-relative offset
     #[inline(always)]
     pub fn get_absolute_y(&self, x: i32, y_offset: i32, z: i32) -> i32 {

--- a/tests/biome_registry.rs
+++ b/tests/biome_registry.rs
@@ -1,4 +1,5 @@
 #[path = "../src/biome_definitions.rs"]
+#[allow(dead_code)]
 mod biome_definitions;
 #[path = "../src/biome_registry.rs"]
 mod biome_registry;

--- a/tests/block_registry.rs
+++ b/tests/block_registry.rs
@@ -3,6 +3,7 @@ mod block_definitions;
 #[path = "../src/block_registry.rs"]
 mod block_registry;
 #[path = "../src/colors.rs"]
+#[allow(dead_code)]
 mod colors;
 
 use block_definitions::*;


### PR DESCRIPTION
## Summary
- gate test-only Biome helpers and cache behind test cfg
- replace unreachable rail pattern with equality check
- drop unused `ground_level` method
- silence test imports for unused helpers

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c7b4a43600832f8b5d64d7e97d24d0