### PR TITLE
Resolve merge markers in waterways processing

### DIFF
--- a/src/element_processing/waterways.rs
+++ b/src/element_processing/waterways.rs
@@ -73,15 +73,10 @@ fn infer_width_from_tags(tags: &HashMap<String, String>, default_blocks: i32, sc
 pub fn generate_waterways(editor: &mut WorldEditor, element: &ProcessedWay, args: &Args) {
     if let Some(waterway_type) = element.tags.get("waterway") {
         let (default_width_blocks, waterway_depth) = get_waterway_dimensions(waterway_type);
-<<<<<<< HEAD
         let scaled_default =
             ((default_width_blocks as f32) * args.scale as f32).clamp(1.0, 5000.0) as i32;
         let waterway_width =
             infer_width_from_tags(&element.tags, scaled_default, args.scale as f32);
-=======
-        let scaled_default = ((default_width_blocks as f32) * args.scale as f32).clamp(1.0, 5000.0) as i32;
-        let waterway_width = infer_width_from_tags(&element.tags, scaled_default, args.scale as f32);
->>>>>>> master
 
         // Skip layers below the ground level
         if matches!(
@@ -118,7 +113,6 @@ pub fn generate_waterways(editor: &mut WorldEditor, element: &ProcessedWay, args
 /// Determines width and depth based on waterway type
 fn get_waterway_dimensions(waterway_type: &str) -> (i32, i32) {
     match waterway_type {
-<<<<<<< HEAD
         "river" => (30, 4),          // Large rivers: 30 blocks wide, 4 blocks deep
         "canal" => (16, 3),          // Canals: 16 blocks wide, 3 blocks deep
         "stream" => (6, 2),          // Streams: 6 blocks wide, 2 blocks deep
@@ -127,16 +121,6 @@ fn get_waterway_dimensions(waterway_type: &str) -> (i32, i32) {
         "brook" | "ditch" => (4, 2), // Small channels: 4 blocks wide, 2 blocks deep
         "drain" => (4, 2),           // Drainage: 4 blocks wide, 2 blocks deep
         _ => (8, 2),                 // Default: 8 blocks wide, 2 blocks deep
-=======
-        "river" => (30, 4),   // Large rivers: 30 blocks wide, 4 blocks deep
-        "canal" => (16, 3),   // Canals: 16 blocks wide, 3 blocks deep
-        "stream" => (6, 2),   // Streams: 6 blocks wide, 2 blocks deep
-        "fairway" => (12, 3), // Shipping fairways: 12 blocks wide, 3 blocks deep
-        "flowline" => (2, 1), // Water flow lines: 2 blocks wide, 1 block deep
-        "brook" | "ditch" => (4, 2), // Small channels: 4 blocks wide, 2 blocks deep
-        "drain" => (4, 2),    // Drainage: 4 blocks wide, 2 blocks deep
-        _ => (8, 2),           // Default: 8 blocks wide, 2 blocks deep
->>>>>>> master
     }
 }
 


### PR DESCRIPTION
## Summary
- remove leftover conflict markers in `generate_waterways` and `get_waterway_dimensions`
- keep the intended width scaling and default dimension logic intact

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68c8a4691990832fbaa3978e85d90524