### PR TITLE
Ensure powered rails receive redstone power

### DIFF
--- a/src/element_processing/railways.rs
+++ b/src/element_processing/railways.rs
@@ -70,7 +70,6 @@ pub fn generate_railways(editor: &mut WorldEditor, element: &ProcessedWay) {
                         || rail_block == RAIL_ASCENDING_NORTH
                         || rail_block == RAIL_ASCENDING_SOUTH)
                 {
-                    editor.set_block(REDSTONE_BLOCK, bx, 0, bz, None, None);
                     let shape = if rail_block == RAIL_EAST_WEST {
                         "east_west"
                     } else if rail_block == RAIL_ASCENDING_EAST {
@@ -89,6 +88,14 @@ pub fn generate_railways(editor: &mut WorldEditor, element: &ProcessedWay) {
                         ("powered".to_string(), Value::String("true".to_string())),
                     ]));
                     let absolute_y = editor.get_absolute_y(bx, 1, bz);
+                    editor.set_block_absolute(
+                        REDSTONE_BLOCK,
+                        bx,
+                        absolute_y - 1,
+                        bz,
+                        None,
+                        Some(&[]),
+                    );
                     editor.set_block_with_properties_absolute(
                         BlockWithProperties::new(POWERED_RAIL, Some(properties)),
                         bx,


### PR DESCRIPTION
## Summary
- ensure powered rails replace the support block beneath them with a redstone block so they remain powered

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68c8b6cf5e30832fa301fc876cf405d6