### PR TITLE
Fix powered rail placement to use relative setter

### DIFF
--- a/src/element_processing/railways.rs
+++ b/src/element_processing/railways.rs
@@ -87,19 +87,11 @@ pub fn generate_railways(editor: &mut WorldEditor, element: &ProcessedWay) {
                         ("shape".to_string(), Value::String(shape.to_string())),
                         ("powered".to_string(), Value::String("true".to_string())),
                     ]));
-                    let absolute_y = editor.get_absolute_y(bx, 1, bz);
-                    editor.set_block_absolute(
-                        REDSTONE_BLOCK,
-                        bx,
-                        absolute_y - 1,
-                        bz,
-                        None,
-                        Some(&[]),
-                    );
-                    editor.set_block_with_properties_absolute(
+                    editor.set_block(REDSTONE_BLOCK, bx, 0, bz, None, None);
+                    editor.set_block_with_properties(
                         BlockWithProperties::new(POWERED_RAIL, Some(properties)),
                         bx,
-                        absolute_y,
+                        1,
                         bz,
                         None,
                         None,

--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -600,6 +600,41 @@ impl<'a> WorldEditor<'a> {
         }
     }
 
+    /// Sets a block with properties at the given coordinates.
+    #[inline]
+    pub fn set_block_with_properties(
+        &mut self,
+        block_with_props: BlockWithProperties,
+        x: i32,
+        y: i32,
+        z: i32,
+        override_whitelist: Option<&[Block]>,
+        override_blacklist: Option<&[Block]>,
+    ) {
+        if !self.xzbbox.contains(&XZPoint::new(x, z)) {
+            return;
+        }
+
+        let absolute_y = self.get_absolute_y(x, y, z);
+
+        let should_insert = if let Some(existing_block) = self.world.get_block(x, absolute_y, z) {
+            if let Some(whitelist) = override_whitelist {
+                whitelist.contains(&existing_block)
+            } else if let Some(blacklist) = override_blacklist {
+                !blacklist.contains(&existing_block)
+            } else {
+                false
+            }
+        } else {
+            true
+        };
+
+        if should_insert {
+            self.world
+                .set_block_with_properties(x, absolute_y, z, block_with_props);
+        }
+    }
+
     /// Sets a block of the specified type at the given coordinates with absolute Y value.
     #[inline]
     pub fn set_block_absolute(


### PR DESCRIPTION
## Summary
- add a relative `WorldEditor::set_block_with_properties` helper so generators can place blocks with state via the normal placement path
- switch railway powered-rail placement to the relative setter to ensure shapes and power states persist and place the redstone block beneath the rail

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68c8bbf7df50832fa9b76686665f9ad7