### PR TITLE
Improve performance of highway generation and chunk serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ version = "2.3.0"
 dependencies = [
  "clap",
  "colored",
+ "dashmap",
  "dirs",
  "fastanvil",
  "fastnbt",
@@ -1112,6 +1113,19 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.95",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ dirs = {version = "6.0.0", optional = true }
 fastanvil = "0.32.0"
 fastnbt = "2.5.0"
 flate2 = "1.1"
+dashmap = "5"
 fnv = "1.0.7"
 fs2 = "0.4"
 geo = "0.30.0"


### PR DESCRIPTION
## Summary
- gate highway logging behind the debug flag and only emit summary messages for placed/fallback signs
- canonicalize palette names in-place, skip serializing empty block-state data, and streamline sign text JSON creation
- replace the global stair cache mutex with DashMap to reduce contention while keeping behavior unchanged

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf74d5b93c832fa39de4746ed38aa2