### PR TITLE
Fix clippy lint warnings

### DIFF
--- a/src/block_definitions.rs
+++ b/src/block_definitions.rs
@@ -173,7 +173,7 @@ impl Block {
 // Cache for stair blocks with properties
 #[allow(clippy::type_complexity)]
 static STAIR_CACHE: Lazy<DashMap<(Block, StairFacing, StairShape), BlockWithProperties>> =
-    Lazy::new(|| DashMap::new());
+    Lazy::new(DashMap::new);
 
 // General function to create any stair block with facing and shape properties
 pub fn create_stair_with_properties(

--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -530,12 +530,10 @@ fn generate_highways_internal(
                                     "  Fallback placed sign for '{name}' at ({sign_x}, {sign_y}, {sign_z})"
                                 );
                             }
-                        } else {
-                            if debug {
-                                eprintln!(
-                                    "  Fallback sign for '{name}' out of bounds at ({sign_x}, {sign_y}, {sign_z})"
-                                );
-                            }
+                        } else if debug {
+                            eprintln!(
+                                "  Fallback sign for '{name}' out of bounds at ({sign_x}, {sign_y}, {sign_z})"
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- remove redundant closure when initializing the stair cache to satisfy clippy
- collapse the fallback sign debug branch to avoid the collapsible-else lint

## Testing
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_68d08ca3704c832fbfff59d6ec3655d5