### PR TITLE
Use is_multiple_of for clippy compliance

### DIFF
--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -190,7 +190,7 @@ pub fn generate_world(
             editor.set_block_absolute(BEDROCK, x, MIN_Y, z, None, Some(&[BEDROCK]));
 
             block_counter += 1;
-            if block_counter % batch_size == 0 {
+            if block_counter.is_multiple_of(batch_size) {
                 ground_pb.inc(batch_size);
             }
 

--- a/src/floodfill.rs
+++ b/src/floodfill.rs
@@ -160,7 +160,7 @@ fn original_flood_fill_area(
     for z in (min_z..=max_z).step_by(step_z as usize) {
         for x in (min_x..=max_x).step_by(step_x as usize) {
             // Reduced timeout checking frequency for better performance
-            if global_visited.len() % 200 == 0 {
+            if global_visited.len().is_multiple_of(200) {
                 if let Some(timeout) = timeout {
                     if &start_time.elapsed() > timeout {
                         return filled_area;


### PR DESCRIPTION
## Summary
- replace manual modulus checks with `is_multiple_of` in ground generation and flood fill progress loops
- keeps progress updates consistent while satisfying clippy's `manual_is_multiple_of` lint

## Testing
- cargo clippy --all-targets --all-features -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68d0a63b357c832fb8603b268b38390f